### PR TITLE
Fix undefined vim.g.neural.ui in lua

### DIFF
--- a/autoload/neural.vim
+++ b/autoload/neural.vim
@@ -153,6 +153,8 @@ endfunction
 
 function! neural#OpenPrompt() abort
     if has('nvim')
+        " Reload the Neural config on a prompt request if needed.
+        call neural#config#Load()
         " In Neovim, try to use the fancy prompt UI, if we can.
         lua require('neural').prompt()
     else


### PR DESCRIPTION
Hi @w0rp, I find a preblem with `<Plug>(neural_prompt)`

```vim
let g:neural = {
  \   'source': {
  \       'openai': {
  \           'api_key': $OPENAI_API_KEY,
  \       },
  \       'chatgpt': {
  \           'api_key': $OPENAI_API_KEY,
  \       },
  \   },
  \   'selected': 'chatgpt'
  \}

nmap <silent> <leader>gzz <Plug>(neural_prompt)
```

I will encounter a error after I type `<leader>gzz` due to the`vim.g.neural.ui` is not defined in this [line](https://github.com/dense-analysis/neural/blob/77862e54c6478c021a2addf5c2883957df44bc9c/lua/neural.lua#L25). This pr fix it, it loads nerual config before open nui
