### PR TITLE
Feat: Add token counting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 tags
 # pyenv
 .python-version
+# python venv
+venv

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "python3/deps/tiktoken"]
+	path = python3/deps/tiktoken
+	url = https://github.com/openai/tiktoken.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "python3/deps/tiktoken"]
-	path = python3/deps/tiktoken
-	url = https://github.com/openai/tiktoken.git

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A ChatGPT Vim plugin, an OpenAI Neovim plugin, and so much more! Neural integrat
 * Focused on privacy and avoiding leaking data to third parties
 * Easily ask AI to explain code or paragraphs `:NeuralExplain`
 * Compatible with Vim 8.0+ & Neovim 0.8+
-* Supported on Linux, Mac OSX, and Windows
+* Supports Linux, Mac OSX, and Windows
 * Only dependency is Python 3.7+
 
 Experience lightning-fast code generation and completion with asynchronous
@@ -28,6 +28,7 @@ them for a better experience.
 
 - [nui.nvim](https://github.com/MunifTanjim/nui.nvim) - for Neovim UI support
 - [significant.nvim](https://github.com/ElPiloto/significant.nvim) - for Neovim animated signs
+- [nvim-notify](https://github.com/rcarriga/nvim-notify) - for Neovim animated notifications
 - [ALE](https://github.com/dense-analysis/ale) - For correcting problems with
   generated code
 

--- a/autoload/neural.vim
+++ b/autoload/neural.vim
@@ -3,6 +3,7 @@
 
 " The location of Neural source scripts
 let s:neural_script_dir = expand('<sfile>:p:h:h') . '/neural_sources'
+let s:neural_python_dir = expand('<sfile>:p:h:h') . '/python3'
 " Keep track of the current job.
 let s:current_job = get(s:, 'current_job', 0)
 " Keep track of the line the last request happened on.
@@ -21,6 +22,11 @@ endfunction
 " Get the Neural scripts directory in a way that makes it hard to modify.
 function! neural#GetScriptDir() abort
     return s:neural_script_dir
+endfunction
+
+" Get the Neural scripts directory in a way that makes it hard to modify.
+function! neural#GetPythonDir() abort
+    return s:neural_python_dir
 endfunction
 
 " Output an error message. The message should be a string.

--- a/autoload/neural.vim
+++ b/autoload/neural.vim
@@ -24,11 +24,6 @@ function! neural#GetScriptDir() abort
     return s:neural_script_dir
 endfunction
 
-" Get the Neural scripts directory in a way that makes it hard to modify.
-function! neural#GetPythonDir() abort
-    return s:neural_python_dir
-endfunction
-
 " Output an error message. The message should be a string.
 " The output error lines will be split in a platform-independent way.
 function! neural#OutputErrorMessage(message) abort

--- a/autoload/neural/count.vim
+++ b/autoload/neural/count.vim
@@ -1,0 +1,124 @@
+" Author: Anexon <anexon@protonmail.com>
+" Description: Count the number of tokens in some input of text.
+
+let s:current_job = get(s:, 'current_count_job', 0)
+
+function! s:AddOutputLine(buffer, job_data, line) abort
+    call add(a:job_data.output_lines, a:line)
+endfunction
+
+function! s:AddErrorLine(buffer, job_data, line) abort
+    call add(a:job_data.error_lines, a:line)
+endfunction
+
+function! s:HandleOutputEnd(buffer, job_data, exit_code) abort
+    " Output an error message from the program if something goes wrong.
+    if a:exit_code != 0
+        " Complain when something goes wrong.
+        call neural#OutputErrorMessage(join(a:job_data.error_lines, "\n"))
+    else
+        if has('nvim')
+            execute 'lua require(''neural'').notify("' . a:job_data.output_lines[0] . '", "info")'
+        else
+            call neural#preview#Show(
+            \   a:job_data.output_lines[0],
+            \   {'stay_here': 1},
+            \)
+        endif
+    endif
+
+    let s:current_job = 0
+endfunction
+
+
+function! neural#count#Cleanup() abort
+    if s:current_job
+        call neural#job#Stop(s:current_job)
+        let s:current_job = 0
+    endif
+endfunction
+
+
+" TODO: Refactor
+" Get the path to the executable for a script language.
+function! s:GetScriptExecutable(source) abort
+    if a:source.script_language is# 'python'
+        let l:executable = ''
+
+        if has('win32')
+            " Try to automatically find Python on Windows, even if not in PATH.
+            let l:executable = expand('~/AppData/Local/Programs/Python/Python3*/python.exe')
+        endif
+
+        if empty(l:executable)
+            let l:executable = 'python3'
+        endif
+
+        return l:executable
+    endif
+
+    throw 'Unknown script language: ' . a:source.script_language
+endfunction
+
+" TODO: Refactor
+function! neural#count#GetCommand(buffer) abort
+    let l:source = {
+    \   'name': 'openai',
+    \   'script_language': 'python',
+    \   'script': neural#GetPythonDir() . '/utils.py',
+    \}
+
+    let l:script_exe = s:GetScriptExecutable(l:source)
+    let l:command = neural#Escape(l:script_exe)
+    \   . ' ' . neural#Escape(l:source.script)
+    let l:command = neural#job#PrepareCommand(a:buffer, l:command)
+
+    return [l:source, l:command]
+endfunction
+
+
+function! neural#count#SelectedLines() abort
+    " Reload the Neural config if needed.
+    " call neural#config#Load()
+    " Stop Neural doing anything else if explaining code.
+    " call neural#Cleanup()
+    let l:range = neural#visual#GetRange()
+    let l:buffer = bufnr('')
+
+    let [l:source, l:command] = neural#count#GetCommand(l:buffer)
+
+    let l:job_data = {
+    \   'output_lines': [],
+    \   'error_lines': [],
+    \}
+    let l:job_id = neural#job#Start(l:command, {
+    \   'mode': 'nl',
+    \   'out_cb': {job_id, line -> s:AddOutputLine(l:buffer, l:job_data, line)},
+    \   'err_cb': {job_id, line -> s:AddErrorLine(l:buffer, l:job_data, line)},
+    \   'exit_cb': {job_id, exit_code -> s:HandleOutputEnd(l:buffer, l:job_data, exit_code)},
+    \})
+
+    if l:job_id > 0
+        " let l:lines = neural#redact#PasswordsAndSecrets(l:range.selection)
+        let l:lines = l:range.selection
+
+        let l:config = get(g:neural.source, l:source.name, {})
+
+        " If the config is not a Dictionary, throw it away.
+        if type(l:config) isnot v:t_dict
+            let l:config = {}
+        endif
+
+        let l:input = {
+        \   'model': l:config,
+        \   'text': join(l:lines, "\n"),
+        \}
+        call neural#job#SendRaw(l:job_id, json_encode(l:input) . "\n")
+    else
+        call neural#OutputErrorMessage('Failed to run ' . l:source.name)
+
+        return
+    endif
+
+    let s:current_job = l:job_id
+endfunction

--- a/autoload/neural/count.vim
+++ b/autoload/neural/count.vim
@@ -1,22 +1,10 @@
 " Author: Anexon <anexon@protonmail.com>
-" Description: Count the number of tokens in some input of text.
+" Description: Count the number of tokens in a given input of text.
 
 let s:current_job = get(s:, 'current_count_job', 0)
 
-function! s:AddOutputLine(buffer, job_data, line) abort
-    call add(a:job_data.output_lines, a:line)
-endfunction
-
-function! s:AddErrorLine(buffer, job_data, line) abort
-    call add(a:job_data.error_lines, a:line)
-endfunction
-
-function! s:HandleOutputEnd(buffer, job_data, exit_code) abort
-    " Output an error message from the program if something goes wrong.
-    if a:exit_code != 0
-        " Complain when something goes wrong.
-        call neural#OutputErrorMessage(join(a:job_data.error_lines, "\n"))
-    else
+function! s:HandleOutputEnd(job_data, exit_code) abort
+    if a:exit_code == 0
         if has('nvim')
             execute 'lua require(''neural'').notify("' . a:job_data.output_lines[0] . '", "info")'
         else
@@ -25,97 +13,38 @@ function! s:HandleOutputEnd(buffer, job_data, exit_code) abort
             \   {'stay_here': 1},
             \)
         endif
+    else
+        call neural#OutputErrorMessage(join(a:job_data.error_lines, "\n"))
     endif
 
+    call neural#job#Stop(s:current_job)
     let s:current_job = 0
 endfunction
 
-
-function! neural#count#Cleanup() abort
-    if s:current_job
-        call neural#job#Stop(s:current_job)
-        let s:current_job = 0
-    endif
-endfunction
-
-
-" TODO: Refactor
-" Get the path to the executable for a script language.
-function! s:GetScriptExecutable(source) abort
-    if a:source.script_language is# 'python'
-        let l:executable = ''
-
-        if has('win32')
-            " Try to automatically find Python on Windows, even if not in PATH.
-            let l:executable = expand('~/AppData/Local/Programs/Python/Python3*/python.exe')
-        endif
-
-        if empty(l:executable)
-            let l:executable = 'python3'
-        endif
-
-        return l:executable
-    endif
-
-    throw 'Unknown script language: ' . a:source.script_language
-endfunction
-
-" TODO: Refactor
-function! neural#count#GetCommand(buffer) abort
-    let l:source = {
-    \   'name': 'openai',
-    \   'script_language': 'python',
-    \   'script': neural#GetPythonDir() . '/utils.py',
-    \}
-
-    let l:script_exe = s:GetScriptExecutable(l:source)
-    let l:command = neural#Escape(l:script_exe)
-    \   . ' ' . neural#Escape(l:source.script)
-    let l:command = neural#job#PrepareCommand(a:buffer, l:command)
-
-    return [l:source, l:command]
-endfunction
-
-
 function! neural#count#SelectedLines() abort
-    " Reload the Neural config if needed.
+    " TODO: Reload the Neural config if needed and pass.
     " call neural#config#Load()
-    " Stop Neural doing anything else if explaining code.
-    " call neural#Cleanup()
-    let l:range = neural#visual#GetRange()
-    let l:buffer = bufnr('')
-
-    let [l:source, l:command] = neural#count#GetCommand(l:buffer)
-
+    " TODO: Should be able to get this elsewhere from a factory-like method.
     let l:job_data = {
     \   'output_lines': [],
     \   'error_lines': [],
     \}
-    let l:job_id = neural#job#Start(l:command, {
+    let l:job_id = neural#job#Start(neural#utils#GetPythonCommand('utils.py'), {
     \   'mode': 'nl',
-    \   'out_cb': {job_id, line -> s:AddOutputLine(l:buffer, l:job_data, line)},
-    \   'err_cb': {job_id, line -> s:AddErrorLine(l:buffer, l:job_data, line)},
-    \   'exit_cb': {job_id, exit_code -> s:HandleOutputEnd(l:buffer, l:job_data, exit_code)},
+    \   'out_cb': {job_id, line -> add(l:job_data.output_lines, line)},
+    \   'err_cb': {job_id, line -> add(l:job_data.error_lines, line)},
+    \   'exit_cb': {job_id, exit_code -> s:HandleOutputEnd(l:job_data, exit_code)},
     \})
 
     if l:job_id > 0
-        " let l:lines = neural#redact#PasswordsAndSecrets(l:range.selection)
-        let l:lines = l:range.selection
-
-        let l:config = get(g:neural.source, l:source.name, {})
-
-        " If the config is not a Dictionary, throw it away.
-        if type(l:config) isnot v:t_dict
-            let l:config = {}
-        endif
+        let l:lines = neural#visual#GetRange().selection
 
         let l:input = {
-        \   'model': l:config,
         \   'text': join(l:lines, "\n"),
         \}
         call neural#job#SendRaw(l:job_id, json_encode(l:input) . "\n")
     else
-        call neural#OutputErrorMessage('Failed to run ' . l:source.name)
+        call neural#OutputErrorMessage('Failed to cound tokens')
 
         return
     endif

--- a/autoload/neural/count.vim
+++ b/autoload/neural/count.vim
@@ -44,7 +44,7 @@ function! neural#count#SelectedLines() abort
         \}
         call neural#job#SendRaw(l:job_id, json_encode(l:input) . "\n")
     else
-        call neural#OutputErrorMessage('Failed to cound tokens')
+        call neural#OutputErrorMessage('Failed to count tokens')
 
         return
     endif

--- a/autoload/neural/count.vim
+++ b/autoload/neural/count.vim
@@ -5,18 +5,23 @@ let s:current_job = get(s:, 'current_count_job', 0)
 
 function! s:HandleOutputEnd(job_data, exit_code) abort
     if a:exit_code == 0
+        let l:output = a:job_data.output_lines[0]
+
         if has('nvim')
-            execute 'lua require(''neural'').notify("' . a:job_data.output_lines[0] . '", "info")'
+            execute 'lua require(''neural.notify'').info("' . l:output . '")'
         else
-            call neural#preview#Show(
-            \   a:job_data.output_lines[0],
-            \   {'stay_here': 1},
-            \)
+            call neural#preview#Show(l:output, {'stay_here': 1})
         endif
+    " Handle error
     else
-        call neural#OutputErrorMessage(join(a:job_data.error_lines, "\n"))
+        if has('nvim')
+            execute 'lua require(''neural.notify'').error("' . join(a:job_data.output_lines, "\n") . '")'
+        else
+            call neural#OutputErrorMessage(join(a:job_data.error_lines, "\n"))
+        endif
     endif
 
+    " Cleanup
     call neural#job#Stop(s:current_job)
     let s:current_job = 0
 endfunction

--- a/autoload/neural/utils.vim
+++ b/autoload/neural/utils.vim
@@ -1,0 +1,84 @@
+" Author: Anexon <anexon@protonmail.com>
+" Co-author: w0rp <devw0rp@gmail.com>
+" Description: Utils and helpers with API normalised between Neovim/Vim 8 and
+" platform independent.
+
+let s:python_script_dir = expand('<sfile>:p:h:h:h') . '/python3'
+
+function! s:IsWindows() abort
+    return has('win32') || has('win64')
+endfunction
+
+" Return string of full neural python script path.
+function! s:GetPythonScript(script) abort
+    return s:python_script_dir . '/' . a:script
+endfunction
+
+" Return path of python executable.
+function! s:GetPython() abort
+    " Use the virtual environment if it exists.
+    if neural#utils#IsVenvAvailable()
+        return s:python_script_dir . '/venv/bin/python3'
+    else
+        let l:python = ''
+
+        " Try to automatically find Python on Windows, even if not in PATH.
+        if s:IsWindows()
+            let l:python = expand('~/AppData/Local/Programs/Python/Python3*/python.exe')
+        endif
+
+        " Fallback to the system Python path
+        if empty(l:python)
+            let l:python = 'python3'
+        endif
+
+        return l:python
+    endif
+endfunction
+
+" Check the virtual environment exist.
+function! neural#utils#IsVenvAvailable() abort
+    let l:venv_dir = s:python_script_dir . '/venv'
+    let l:venv_python = l:venv_dir . (s:IsWindows() ? '\Scripts\python.exe' : '/bin/python')
+
+    return isdirectory(l:venv_dir) && filereadable(l:venv_python) && executable(l:venv_python)
+endfunction
+
+" Returns python command call for a given neural python script.
+function! neural#utils#GetPythonCommand(script) abort
+    let l:script = neural#utils#StringEscape(s:GetPythonScript(a:script))
+    let l:python = neural#utils#StringEscape(s:GetPython())
+
+    return neural#utils#GetCommand(l:python . ' ' . l:script)
+endfunction
+
+" Return a command that should be executed in a subshell.
+"
+" This fixes issues related to PATH variables, %PATHEXT% in Windows, etc.
+" Neovim handles this automatically if the command is a String, but we do
+" this explicitly for consistency.
+function! neural#utils#GetCommand(command) abort
+    if s:IsWindows()
+        return 'cmd /s/c "' . a:command . '"'
+    endif
+
+    return ['/bin/sh', '-c', a:command]
+endfunction
+
+" Return platform independent escaped String.
+function! neural#utils#StringEscape(str) abort
+    if fnamemodify(&shell, ':t') is? 'cmd.exe'
+        " If the string contains spaces, it will be surrounded by quotes.
+        " Otherwise, special characters will be escaped with carets (^).
+        return substitute(
+        \   a:str =~# ' '
+        \       ?  '"' .  substitute(a:str, '"', '""', 'g') . '"'
+        \       : substitute(a:str, '\v([&|<>^])', '^\1', 'g'),
+        \   '%',
+        \   '%%',
+        \   'g',
+        \)
+    endif
+
+    return shellescape (a:str)
+endfunction

--- a/autoload/neural/utils.vim
+++ b/autoload/neural/utils.vim
@@ -1,5 +1,4 @@
-" Author: Anexon <anexon@protonmail.com>
-" Co-author: w0rp <devw0rp@gmail.com>
+" Author: Anexon <anexon@protonmail.com>, w0rp <devw0rp@gmail.com>
 " Description: Utils and helpers with API normalised between Neovim/Vim 8 and
 " platform independent.
 

--- a/build.lua
+++ b/build.lua
@@ -1,0 +1,45 @@
+local function is_windows()
+    return vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
+end
+
+local function get_path_separator()
+    return is_windows() and "\\" or "/"
+end
+
+local function get_script_path()
+    local path_sep = get_path_separator()
+    local script_path = debug.getinfo(1).source:match("@?(.*)" .. path_sep)
+
+    return script_path or ""
+end
+
+local function run_command(command)
+    local status, _, code = os.execute(command)
+
+    require('notify').notify('Command: ' .. command .. ' || status: ' .. status, 'info')
+    require('notify').notify('status: ' .. status, 'info')
+
+    if status == false then
+        error("Command failed: " .. command .. ". Exit code: " .. tostring(code))
+    end
+end
+
+local function setup()
+    local python = is_windows() and "python" or "python3"
+    local sep = get_path_separator()
+    local script_path = get_script_path()
+    local venv_path = script_path .. sep .. "python3" .. sep .. "venv"
+
+    -- Create virtual environment if it does not exist.
+    if vim.fn.isdirectory(venv_path) == 0 then
+        run_command(python .. " -m venv " .. venv_path)
+    end
+
+    -- Install requirements via pip
+    local pip_cmd = venv_path .. (is_windows() and sep .. "Scripts" .. sep .. "pip" or sep .. "bin" .. sep .. "pip")
+    local requirements_path = script_path .. sep .. "python3" .. sep .. "requirements.txt"
+
+    run_command(pip_cmd .. " install -r " .. requirements_path)
+end
+
+setup()

--- a/lua/neural.lua
+++ b/lua/neural.lua
@@ -1,8 +1,11 @@
 -- External dependencies
-local UI = {}
-local AnimatedSign = {}
 local has_nui, _ = pcall(require, 'nui.input')
 local has_significant, _ = pcall(require, 'significant')
+local has_notify, _ = pcall(require, 'notify')
+
+local UI = {}
+local AnimatedSign = {}
+local Notify = {}
 
 if has_nui then
     UI = require('neural.ui')
@@ -10,6 +13,10 @@ end
 
 if has_significant then
     AnimatedSign = require('significant')
+end
+
+if has_notify then
+  Notify = require('notify')
 end
 
 local Neural = {}
@@ -52,6 +59,18 @@ function Neural.stop_animated_sign(line)
     if has_significant and (sign_enabled and sign_enabled ~= 0) and line > 0 then
         AnimatedSign.stop_animated_sign(line, {unplace_sign=true})
     end
+end
+
+function Neural.notify(message, level)
+  if has_notify then
+    local opts = {
+      title = 'Neural - Token Count',
+      icon = vim.g.neural.ui.prompt_icon
+    }
+    Notify(message, level, opts)
+  else
+    vim.fn['neural#preview#Show'](message, {stay_here = 1})
+  end
 end
 
 return Neural

--- a/lua/neural.lua
+++ b/lua/neural.lua
@@ -1,22 +1,9 @@
 -- External dependencies
 local has_nui, _ = pcall(require, 'nui.input')
-local has_significant, _ = pcall(require, 'significant')
-local has_notify, _ = pcall(require, 'notify')
-
-local UI = {}
-local AnimatedSign = {}
-local Notify = {}
+local has_significant, AnimatedSign = pcall(require, 'significant')
 
 if has_nui then
     UI = require('neural.ui')
-end
-
-if has_significant then
-    AnimatedSign = require('significant')
-end
-
-if has_notify then
-  Notify = require('notify')
 end
 
 local Neural = {}

--- a/plugin/neural.vim
+++ b/plugin/neural.vim
@@ -37,6 +37,8 @@ command! -nargs=0 NeuralStop :call neural#Stop()
 command! -nargs=? NeuralBuffer :call neural#buffer#CreateBuffer(<q-args>)
 " Have Neural explain the visually selected lines.
 command! -range NeuralExplain :call neural#explain#SelectedLines()
+" Get the token count for the visually selected lines.
+command! -range NeuralCountTokens :call neural#count#SelectedLines()
 
 " <Plug> mappings for commands
 nnoremap <silent> <Plug>(neural_prompt) :call neural#OpenPrompt()<Return>

--- a/python3/requirements.txt
+++ b/python3/requirements.txt
@@ -1,0 +1,1 @@
+tiktoken

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -1,46 +1,7 @@
-import os
 import sys
 import json
 
-sys.path.append('./deps/tiktoken')
-#
-# # import tiktoken
-# from .deps import tiktoken
-
-# script_dir = os.path.dirname(os.path.realpath(__file__))
-# parent_dir = os.path.dirname(script_dir)
-# deps_path = os.path.join(parent_dir, 'deps')
-# sys.path.append(deps_path)
-
-
-# Calculate the absolute path to the 'deps' directory
-# /home/user/.config/nvim/projects/neural/python3
-script_dir = os.path.dirname(os.path.realpath(__file__))
-
-# /home/user/.config/nvim/projects/neural/python2/deps
-tiktoken_dir = os.path.abspath(os.path.join(script_dir, 'deps/tiktoken'))
-regex_dir = os.path.abspath(os.path.join(script_dir, 'deps/mrab-regex'))
-regex_dir2 = os.path.abspath(os.path.join(script_dir, 'deps/mrab-regex/regex_3'))
-
-# Add 'deps' directory to sys.path if it's not already there
-if tiktoken_dir not in sys.path:
-    sys.path.insert(0, tiktoken_dir)
-
-if regex_dir not in sys.path:
-    sys.path.insert(0, regex_dir)
-if regex_dir2 not in sys.path:
-    sys.path.insert(0, regex_dir2)
-
-# Now you can import tiktoken as if it was a top-level module
-# import deps.tiktoken.tiktoken as tiktoken
-# import regex
-# exit(regex)
 import tiktoken
-
-# import deps.mrabregex.regex_3 as regex
-# import tiktoken
-
-# Rest of your code...
 
 def count_tokens(text: str, model: str ="gpt-3.5-turbo") -> int:
     """
@@ -54,8 +15,8 @@ def count_tokens(text: str, model: str ="gpt-3.5-turbo") -> int:
 if __name__ == "__main__":
     # Read input from command line
     input_data = json.loads(sys.stdin.readline())
-    # input_text = sys.stdin.readline()
 
+    # TODO: Read config
     model = input_data["model"]
 
     # Count tokens

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     input_data = json.loads(sys.stdin.readline())
 
     # TODO: Read config
-    model = input_data["model"]
+    # model = input_data["model"]
 
     # Count tokens
     count = count_tokens(input_data["text"])

--- a/python3/utils.py
+++ b/python3/utils.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import json
+
+sys.path.append('./deps/tiktoken')
+#
+# # import tiktoken
+# from .deps import tiktoken
+
+# script_dir = os.path.dirname(os.path.realpath(__file__))
+# parent_dir = os.path.dirname(script_dir)
+# deps_path = os.path.join(parent_dir, 'deps')
+# sys.path.append(deps_path)
+
+
+# Calculate the absolute path to the 'deps' directory
+# /home/user/.config/nvim/projects/neural/python3
+script_dir = os.path.dirname(os.path.realpath(__file__))
+
+# /home/user/.config/nvim/projects/neural/python2/deps
+tiktoken_dir = os.path.abspath(os.path.join(script_dir, 'deps/tiktoken'))
+regex_dir = os.path.abspath(os.path.join(script_dir, 'deps/mrab-regex'))
+regex_dir2 = os.path.abspath(os.path.join(script_dir, 'deps/mrab-regex/regex_3'))
+
+# Add 'deps' directory to sys.path if it's not already there
+if tiktoken_dir not in sys.path:
+    sys.path.insert(0, tiktoken_dir)
+
+if regex_dir not in sys.path:
+    sys.path.insert(0, regex_dir)
+if regex_dir2 not in sys.path:
+    sys.path.insert(0, regex_dir2)
+
+# Now you can import tiktoken as if it was a top-level module
+# import deps.tiktoken.tiktoken as tiktoken
+# import regex
+# exit(regex)
+import tiktoken
+
+# import deps.mrabregex.regex_3 as regex
+# import tiktoken
+
+# Rest of your code...
+
+def count_tokens(text: str, model: str ="gpt-3.5-turbo") -> int:
+    """
+    Return the number of tokens from an input text using the appropriate
+    tokeniser for the given model.
+    """
+    encoder = tiktoken.encoding_for_model(model)
+
+    return len(encoder.encode(text))
+
+if __name__ == "__main__":
+    # Read input from command line
+    input_data = json.loads(sys.stdin.readline())
+    # input_text = sys.stdin.readline()
+
+    model = input_data["model"]
+
+    # Count tokens
+    count = count_tokens(input_data["text"])
+    print(count)
+
+    # sys.exit(count)


### PR DESCRIPTION
Closes: #41

## Overview
- [x] Add command to count tokens from a visual selection.
- [x] Add python script to count tokens with [OpenAI's tiktoken](https://github.com/openai/tiktoken).
- [x] Add `utils.vim` to launch python scripts more easily.
- [x] Add automatic venv setup for Neovim with [lazy.nvim](https://github.com/folke/lazy.nvim) package manager via `build.lua`.
    - [x] Create a python virtual environment automatically for Linux or Windows (Untested).
    - [x] Install dependencies from `requirements.txt` automatically.
- [x] Add Neovim animated notification integration with [nvim-notify](https://github.com/rcarriga/nvim-notify).

## Todo
- [ ] Check for [tiktoken](https://github.com/openai/tiktoken) dependency in Python script, and throw error if not present.
- [ ] Investigate automatically setting up python venv and installing requirements for vim 8.
- [ ] Update `README.md` to document optionally setting up python venv.
- Update vimdocs:
    - [ ] New command and availability dependant on [tiktoken](https://github.com/openai/tiktoken)
    - [ ] Integration of nvim-notify

## Testing
- Test automatic setup for Neovim with [lazy.nvim](https://github.com/folke/lazy.nvim).
    - [x] Linux
    - [ ] Mac OSX
    - [ ] Windows

## Screenshots

### Neovim Animated Notifications via [nvim-notify](https://github.com/rcarriga/nvim-notify)
![Screenshot_20240103_233935](https://github.com/dense-analysis/neural/assets/38880939/1d666f33-9a5c-4fbd-a4f9-dd14c15c1ba2)

### Automatic venv setup for Neovim with [lazy.nvim](https://github.com/folke/lazy.nvim)
![Screenshot_20240103_234057](https://github.com/dense-analysis/neural/assets/38880939/4e963564-b513-44ff-8cff-163691cbcc77)
