### PR TITLE
Fix OpenAI config bug

### DIFF
--- a/neural_providers/chatgpt.py
+++ b/neural_providers/chatgpt.py
@@ -152,7 +152,7 @@ def load_config(raw_config: Dict[str, Any]) -> Config:
         top_p=top_p,
         max_tokens=max_tokens,
         presence_penalty=presence_penalty,
-        frequency_penalty=presence_penalty,
+        frequency_penalty=frequency_penalty,
     )
 
 

--- a/neural_providers/openai.py
+++ b/neural_providers/openai.py
@@ -142,7 +142,7 @@ def load_config(raw_config: Dict[str, Any]) -> Config:
         top_p=top_p,
         max_tokens=max_tokens,
         presence_penalty=presence_penalty,
-        frequency_penalty=presence_penalty,
+        frequency_penalty=frequency_penalty,
     )
 
 

--- a/test/python/test_chatgpt.py
+++ b/test/python/test_chatgpt.py
@@ -66,6 +66,19 @@ def test_load_config_errors():
         assert str(exc.value) == expected_error, config
 
 
+def test_load_config_valid_values():
+    raw = get_valid_config()
+    cfg = chatgpt.load_config(raw)
+
+    assert cfg.api_key == raw["api_key"]
+    assert cfg.model == raw["model"]
+    assert cfg.temperature == raw["temperature"]
+    assert cfg.top_p == raw["top_p"]
+    assert cfg.max_tokens == raw["max_tokens"]
+    assert cfg.presence_penalty == raw["presence_penalty"]
+    assert cfg.frequency_penalty == raw["frequency_penalty"]
+
+
 def test_main_function_rate_other_error():
     with mock.patch.object(sys.stdin, 'readline') as readline_mock, \
         mock.patch.object(chatgpt, 'get_chatgpt_completion') as compl_mock:

--- a/test/python/test_chatgpt.py
+++ b/test/python/test_chatgpt.py
@@ -68,6 +68,8 @@ def test_load_config_errors():
 
 def test_load_config_valid_values():
     raw = get_valid_config()
+    raw["presence_penalty"] = 0.5
+    raw["frequency_penalty"] = 1.0  
     cfg = chatgpt.load_config(raw)
 
     assert cfg.api_key == raw["api_key"]

--- a/test/python/test_openai.py
+++ b/test/python/test_openai.py
@@ -68,6 +68,8 @@ def test_load_config_errors():
 
 def test_load_config_valid_values():
     raw = get_valid_config()
+    raw["presence_penalty"] = 0.5
+    raw["frequency_penalty"] = 1.0  
     cfg = openai.load_config(raw)
 
     assert cfg.api_key == raw["api_key"]

--- a/test/python/test_openai.py
+++ b/test/python/test_openai.py
@@ -66,6 +66,19 @@ def test_load_config_errors():
         assert str(exc.value) == expected_error, config
 
 
+def test_load_config_valid_values():
+    raw = get_valid_config()
+    cfg = openai.load_config(raw)
+
+    assert cfg.api_key == raw["api_key"]
+    assert cfg.model == raw["model"]
+    assert cfg.temperature == raw["temperature"]
+    assert cfg.top_p == raw["top_p"]
+    assert cfg.max_tokens == raw["max_tokens"]
+    assert cfg.presence_penalty == raw["presence_penalty"]
+    assert cfg.frequency_penalty == raw["frequency_penalty"]
+
+
 def test_main_function_rate_other_error():
     with mock.patch.object(sys.stdin, 'readline') as readline_mock, \
         mock.patch.object(openai, 'get_openai_completion') as completion_mock:


### PR DESCRIPTION
## Summary
- fix `frequency_penalty` field when building config objects
- test that `load_config` preserves all values for OpenAI and ChatGPT providers

## Testing
- `python -m pytest -q`